### PR TITLE
Various docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ that submodules (for third-party dependencies) get pulled too.
 git clone --recursive git@github.com:Bearwaves/growl.git
 ```
 
-1. From the root of the repository, navigate to `example/testapp`, and create
+1. From the root of the repository, navigate to `example/test_app`, and create
 a `build` directory.
 
 1. From your newly created `build` directory, run `cmake ..`. This is known as

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ e.g. `make -j 4` to build with four threads.
 1. Two executables will be built: `growl-test-app` and `growl-cmd`. Use
 `growl-cmd` to generate the asset bundle, like so:
 ```bash
-./growl-cmd assets bundle ../assets/
+./growl-cmd assets bundle ../../assets/
 ```
 
 1. Run the app!

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,8 @@ To build with Growl, you will need the following:
 
 - A modern C++ compiler. Growl has been built with Clang, GCC, MSVC and
 Emscripten.
-- CMake (3.20+)
+- [CMake](https://formulae.brew.sh/formula/cmake) (3.20+)
+- [make](https://formulae.brew.sh/formula/make) (4.4.1+)
 
 Growl assumes familiarity with modern C++ features like smart pointers and  move
 semantics, but it doesn't use anything particularly arcane. Familiarity with


### PR DESCRIPTION
This PR collects various docs fixes that I'm drive by implementing as I read the docs for the first time. @JoelOtter I will let you know when this is ready for review.

**Update: This PR is now ready for review. It includes all fixes necessary to make this setup flow function correctly on macOS. These are:**

- Correct the path to `test_app`
- Correct the `./growl-cmd assets` to take into account the fact that `assets` is two directories back, not one.
- Add make as a dependency.
- Link to the homebrews for make and cmake to help users find dependencies and push them towards using the homebrew workflow that we use.

**I will land a second PR at some point that adds Windows steps and distinguished between Windows and macOS/Linux steps**