### PR TITLE
[SDL] Add missing modifier keys

### DIFF
--- a/src/core/include/growl/core/input/keyboard.h
+++ b/src/core/include/growl/core/input/keyboard.h
@@ -83,6 +83,10 @@ enum class Key {
 	FunctionF23,
 	FunctionF24,
 
+	LeftShift,
+	RightShift,
+	LeftControl,
+	RightControl,
 	Return,
 	Space,
 	Escape,

--- a/src/plugins/sdl3/src/sdl3_keyboard.cpp
+++ b/src/plugins/sdl3/src/sdl3_keyboard.cpp
@@ -203,6 +203,15 @@ Key SDL3SystemAPI::getKey(SDL_KeyboardEvent& event) {
 	case SDL_SCANCODE_F24:
 		return Key::FunctionF24;
 
+	case SDL_SCANCODE_LSHIFT:
+		return Key::LeftShift;
+	case SDL_SCANCODE_RSHIFT:
+		return Key::RightShift;
+	case SDL_SCANCODE_LCTRL:
+		return Key::LeftControl;
+	case SDL_SCANCODE_RCTRL:
+		return Key::RightControl;
+
 	case SDL_SCANCODE_RETURN:
 		return Key::Return;
 	case SDL_SCANCODE_SPACE:
@@ -353,6 +362,14 @@ SDL_Scancode SDL3SystemAPI::getScancode(Key key) {
 	case Key::FunctionF24:
 		return SDL_SCANCODE_F24;
 
+	case Key::LeftShift:
+		return SDL_SCANCODE_LSHIFT;
+	case Key::RightShift:
+		return SDL_SCANCODE_RSHIFT;
+	case Key::LeftControl:
+		return SDL_SCANCODE_LCTRL;
+	case Key::RightControl:
+		return SDL_SCANCODE_RCTRL;
 	case Key::Return:
 		return SDL_SCANCODE_RETURN;
 	case Key::Space:


### PR DESCRIPTION
My character uses LeftShift to sprint, so I added the missing keys in my local fork and included the other keys that I may potentially use